### PR TITLE
Added support for the new DBus library namely dbus-0.10

### DIFF
--- a/xmonad.hs
+++ b/xmonad.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE OverloadedStrings, PackageImports #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 import XMonad
 import XMonad.Config.Gnome
 import XMonad.Hooks.DynamicLog
 
-import qualified "dbus" DBus as D
-import qualified "dbus" DBus.Client as D
+import qualified DBus as D
+import qualified DBus.Client as D
 import qualified Codec.Binary.UTF8.String as UTF8
 
 main :: IO ()

--- a/xmonad.hs
+++ b/xmonad.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, PackageImports #-}
 
 import XMonad
 import XMonad.Config.Gnome
 import XMonad.Hooks.DynamicLog
 
-import qualified DBus.Client.Simple as D
+import qualified "dbus" DBus as D
+import qualified "dbus" DBus.Client as D
 import qualified Codec.Binary.UTF8.String as UTF8
 
 main :: IO ()
@@ -30,15 +31,15 @@ prettyPrinter dbus = defaultPP
 getWellKnownName :: D.Client -> IO ()
 getWellKnownName dbus = do
   D.requestName dbus (D.busName_ "org.xmonad.Log")
-                [D.AllowReplacement, D.ReplaceExisting, D.DoNotQueue]
+                [D.nameAllowReplacement, D.nameReplaceExisting, D.nameDoNotQueue]
   return ()
   
 dbusOutput :: D.Client -> String -> IO ()
-dbusOutput dbus str = D.emit dbus
-                             "/org/xmonad/Log"
-                             "org.xmonad.Log"
-                             "Update"
-                             [D.toVariant ("<b>" ++ (UTF8.decodeString str) ++ "</b>")]
+dbusOutput dbus str = do
+    let signal = (D.signal "/org/xmonad/Log" "org.xmonad.Log" "Update") {
+            D.signalBody = [D.toVariant ("<b>" ++ (UTF8.decodeString str) ++ "</b>")]
+        }
+    D.emit dbus signal
 
 pangoColor :: String -> String -> String
 pangoColor fg = wrap left right


### PR DESCRIPTION
The package dbus-core has been deprecated. I have updated the example xmonad.hs to work with dbus-0.10. I am not sure that using package imports is good practice but it is needed if both dbus and dbus-core or the old DBus packages coexists.
