### PR TITLE
Add support for newer version of libpanelapplet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ install-sh
 missing
 stamp-h1
 xmonad-log-applet
+.libs/
+compile
+libtool
+libxmonad-log-applet.la
+libxmonad_log_applet_la-main.lo
+ltmain.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,36 @@
 plugindir = $(PLUGIN_DIR)
+
+if PANEL_GNOME_IN_PROC
+
+xmonad_log_appletdir = $(libdir)/gnome-panel/modules
+PLUGIN_DIR_ = $(libdir)/gnome-panel/modules
+xmonad_log_applet_LTLIBRARIES = libxmonad-log-applet.la
+PLUGIN_FILE = libxmonad-log-applet.la
+IN_PROC_STR = "InProcess=true"
+
+libxmonad_log_applet_la_SOURCES = main.c
+libxmonad_log_applet_la_CPPFLAGS = \
+	$(GLIB_CFLAGS) \
+	$(DBUS_GLIB_CFLAGS) \
+	$(LIBPANEL_CFLAGS)
+
+libxmonad_log_applet_la_LIBADD = \
+	$(GLIB_LIBS) \
+	$(DBUS_GLIB_LIBS) \
+	$(LIBPANEL_LIBS)
+
+libxmonad_log_applet_la_LDFLAGS = \
+	-module -avoid-version \
+	$(WARN_LDFLAGS) \
+	$(AM_LDFLAGS)
+
+else
+
 plugin_PROGRAMS = xmonad-log-applet
+PLUGIN_DIR_ = $(PLUGIN_DIR)
+PLUGIN_FILE = xmonad-log-applet
 
 xmonad_log_applet_SOURCES = main.c
-
 xmonad_log_applet_CPPFLAGS = \
 	$(GLIB_CFLAGS) \
 	$(DBUS_GLIB_CFLAGS) \
@@ -13,21 +41,29 @@ xmonad_log_applet_LDADD = \
 	$(DBUS_GLIB_LIBS) \
 	$(LIBPANEL_LIBS)
 
+endif
+
 appletdir = $(LIBPANEL_APPLET_DIR)
 if PANEL_GNOME
 applet_files = org.gnome.panel.XmonadLogApplet.panel-applet
 $(applet_files): $(applet_files:.panel-applet=.panel-applet.in)
-	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" $< > $@
+	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR_)|" \
+		   -e "s|\@PLUGIN_FILE\@|$(PLUGIN_FILE)|" \
+		   -e "s|\@IN_PROC\@|$(IN_PROC_STR)|" $< > $@
 endif
 if PANEL_MATE
 applet_files = org.mate.panel.XmonadLogApplet.mate-panel-applet
 $(applet_files): $(applet_files:.mate-panel-applet=.mate-panel-applet.in)
-	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" $< > $@
+	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR_)|" \
+		   -e "s|\@PLUGIN_FILE\@|$(PLUGIN_FILE)|" \
+		   -e "s|\@IN_PROC\@|$(IN_PROC_STR)|" $< > $@
 endif
 if PANEL_XFCE4
 applet_files = xmonad-log-applet.desktop
 $(applet_files): $(applet_files:.desktop=.desktop.in)
-	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" $< > $@
+	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" \
+		   -e "s|\@PLUGIN_FILE\@|$(PLUGIN_FILE)|" \
+		   -e "s|\@IN_PROC\@|$(IN_PROC_STR)|" $< > $@
 endif
 
 applet_DATA = $(applet_files)

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ already running Xmonad within [GNOME][1], MATE or [Xfce][2]:
   [tarball][4], or pull the latest version from the git repository: `git clone
   git://github.com/alexkay/xmonad-log-applet.git`
 
-The applet supports GNOME 2, GNOME 3, MATE and Xfce 4 panels, just pass
+The applet supports GNOME 2, GNOME Flashback, MATE and Xfce 4 panels, just pass
 `--with-panel=X` to `./configure` when compiling, where X is one of gnome2,
-gnome3, mate or xfce4.
+gnome3, gnomeflashback, mate or xfce4. Use gnome3 when compiling for older
+versions of Gnome 3 with libpanelapplet-4.0.
 
 If you are compiling from a git clone, you should run `./autogen.sh` instead of
 `./configure`.

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,10 @@ AM_INIT_AUTOMAKE([foreign])
 
 AM_MAINTAINER_MODE
 
+LT_PREREQ([2.2.6])
+LT_INIT([dlopen disable-static])
+LT_LIB_M
+
 AC_PROG_CC
 AC_PROG_SED
 AC_PROG_INSTALL
@@ -60,6 +64,7 @@ AS_IF(
         ,
     [AC_MSG_ERROR([Unknown panel type, use gnome2, gnome3, gnomeflashback, mate or xfce4])]
 )
+PKG_CHECK_MODULES(LIBPANEL_GE_3_22, libpanel-applet >= 3.22.0, PANEL_GNOME_IN_PROC=1, PANEL_GNOME_IN_PROC=0)
 AC_SUBST([LIBPANEL_APPLET_DIR])
 AC_SUBST([PLUGIN_DIR])
 
@@ -69,6 +74,8 @@ AM_CONDITIONAL([PANEL_GNOME3], [test "x$panel" = xgnome3])
 AM_CONDITIONAL([PANEL_GNOMEFLASHBACK], [test "x$panel" = xgnomeflashback])
 AM_CONDITIONAL([PANEL_MATE], [test "x$panel" = xmate])
 AM_CONDITIONAL([PANEL_XFCE4], [test "x$panel" = xxfce4])
+AM_CONDITIONAL([PANEL_GNOME_IN_PROC], [test "$PANEL_GNOME_IN_PROC" -eq 1])
+AS_IF([test "$PANEL_GNOME_IN_PROC" -eq 1], [AC_DEFINE([PANEL_GNOME_IN_PROC], [1], [Define if using libpanel-applet >= 3.22.0 and we need in process applet.])])
 
 AC_CONFIG_FILES([Makefile])
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_SUBST([SESSION_BUS_SERVICES_DIR])
 
 AC_ARG_WITH(
     [panel],
-    [AS_HELP_STRING([--with-panel], [target gnome2, gnome3, mate or xfce4 (default) panel])],
+    [AS_HELP_STRING([--with-panel], [target gnome2, gnome3, gnomeflashback, mate or xfce4 (default) panel])],
     [panel=$withval],
     [panel=xfce4]
 )
@@ -39,6 +39,13 @@ AS_IF(
         [AC_DEFINE(PANEL_GNOME, 1, [panel type])]
         [AC_DEFINE(PANEL_GNOME3, 1, [panel type])]
         ,
+    [test "x$panel" = xgnomeflashback],
+        [PKG_CHECK_MODULES(LIBPANEL, libpanel-applet >= 3.0.0)]
+        LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=libpanel_applet_dir libpanel-applet`
+        PLUGIN_DIR=`$PKG_CONFIG --variable=prefix libpanel-applet`/libexec
+        [AC_DEFINE(PANEL_GNOME, 1, [panel type])]
+        [AC_DEFINE(PANEL_GNOMEFLASHBACK, 1, [panel type])]
+        ,
     [test "x$panel" = xmate],
         [PKG_CHECK_MODULES(LIBPANEL, libmatepanelapplet-3.0 >= 1.4.0)]
         LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=prefix libmatepanelapplet-3.0`/share/mate-panel/applets
@@ -51,14 +58,15 @@ AS_IF(
         PLUGIN_DIR=`$PKG_CONFIG --variable=libdir libxfce4panel-1.0`/xfce4/panel/plugins
         [AC_DEFINE(PANEL_XFCE4, 1, [panel type])]
         ,
-    [AC_MSG_ERROR([Unknown panel type, use gnome2, gnome3, mate or xfce4])]
+    [AC_MSG_ERROR([Unknown panel type, use gnome2, gnome3, gnomeflashback, mate or xfce4])]
 )
 AC_SUBST([LIBPANEL_APPLET_DIR])
 AC_SUBST([PLUGIN_DIR])
 
-AM_CONDITIONAL([PANEL_GNOME], [test "x$panel" = xgnome2 -o "x$panel" = xgnome3])
+AM_CONDITIONAL([PANEL_GNOME], [test "x$panel" = xgnome2 -o "x$panel" = xgnome3 -o "x$panel" = xgnomeflashback])
 AM_CONDITIONAL([PANEL_GNOME2], [test "x$panel" = xgnome2])
 AM_CONDITIONAL([PANEL_GNOME3], [test "x$panel" = xgnome3])
+AM_CONDITIONAL([PANEL_GNOMEFLASHBACK], [test "x$panel" = xgnomeflashback])
 AM_CONDITIONAL([PANEL_MATE], [test "x$panel" = xmate])
 AM_CONDITIONAL([PANEL_XFCE4], [test "x$panel" = xxfce4])
 

--- a/main.c
+++ b/main.c
@@ -41,7 +41,11 @@ static void set_up_dbus_transfer(GtkWidget *buf)
     if(connection == NULL) {
         g_printerr("Failed to open connection: %s\n", error->message);
         g_error_free(error);
-        exit(1);
+        #ifdef PANEL_GNOME_IN_PROC
+        return;
+        #else
+        exit(-1);
+        #endif
     }
 
     proxy = dbus_g_proxy_new_for_name(
@@ -71,7 +75,9 @@ static void xmonad_log_applet_fill(GtkContainer *container)
         PANEL_APPLET_EXPAND_MINOR |
         PANEL_APPLET_HAS_HANDLE);
 
+    #ifndef PANEL_GNOME_IN_PROC
     panel_applet_set_background_widget(applet, GTK_WIDGET(applet));
+    #endif
 #endif
 #ifdef PANEL_MATE
     mate_panel_applet_set_flags(
@@ -111,7 +117,11 @@ static gboolean xmonad_log_applet_factory(
 
     if(retval == FALSE) {
         printf("Wrong applet!\n");
+        #ifdef PANEL_GNOME_IN_PROC
+        return FALSE;
+        #else
         exit(-1);
+        #endif
     }
 
     return retval;
@@ -128,7 +138,11 @@ static gboolean xmonad_log_applet_factory(
 
     if(retval == FALSE) {
         printf("Wrong applet!\n");
+        #ifdef PANEL_GNOME_IN_PROC
+        return NULL;
+        #else
         exit(-1);
+        #endif
     }
 
     return retval;
@@ -144,7 +158,11 @@ static void xmonad_log_applet_construct(XfcePanelPlugin *plugin)
 #endif
 
 #ifdef PANEL_GNOME
+#ifdef PANEL_GNOME_IN_PROC
+PANEL_APPLET_IN_PROCESS_FACTORY(
+#else
 PANEL_APPLET_OUT_PROCESS_FACTORY(
+#endif
     "XmonadLogAppletFactory",
     PANEL_TYPE_APPLET,
 #ifdef PANEL_GNOME2

--- a/org.gnome.panel.XmonadLogApplet.panel-applet.in
+++ b/org.gnome.panel.XmonadLogApplet.panel-applet.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=XmonadLogAppletFactory
-Location=@PLUGIN_DIR@/xmonad-log-applet
+@IN_PROC@
+Location=@PLUGIN_DIR@/@PLUGIN_FILE@
 Name=Xmonad Log Factory
 Description=Factory for the xmonad-log-applet
 


### PR DESCRIPTION
In the newest versions of, what is now called, Gnome Flashback the
library libpanelapplet-4.0 is now renamed to libpanel-applet. No
changes in the code are necessary. This change adds an extra option
(gnomeflashback) to with-panel argument that will add the correct
library. Also, adds relative changes to README.
